### PR TITLE
Update Alpine base image

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
@@ -16,7 +16,7 @@ jobs:
 
   build:
     name: Test & Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup up Go 1.x
         uses: actions/setup-go@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   push:
     name: Push images
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out code
@@ -67,7 +67,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     # Run only if previous job has succeeded
     needs: [push]

--- a/cmd/cloudstack-csi-driver/Dockerfile
+++ b/cmd/cloudstack-csi-driver/Dockerfile
@@ -1,10 +1,17 @@
-FROM alpine:3.12.3
+FROM alpine:3.14.0
 
 LABEL \
     org.opencontainers.image.description="CloudStack CSI driver" \
     org.opencontainers.image.source="https://github.com/apalia/cloudstack-csi-driver/"
 
-RUN apk add --no-cache xfsprogs e2fsprogs blkid ca-certificates
+RUN apk add --no-cache \
+    ca-certificates \
+    # Provides mkfs.ext2, mkfs.ext3, mkfs.ext4 (used by k8s.io/mount-utils)
+    e2fsprogs \
+    # Provides mkfs.xfs
+    xfsprogs \
+    # Provides blkid, also used by k8s.io/mount-utils
+    blkid
 
 COPY ./bin/cloudstack-csi-driver /cloudstack-csi-driver
 ENTRYPOINT ["/cloudstack-csi-driver"]

--- a/cmd/cloudstack-csi-sc-syncer/Dockerfile
+++ b/cmd/cloudstack-csi-sc-syncer/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.3
+FROM alpine:3.14.0
 
 LABEL \
     org.opencontainers.image.description="CloudStack disk offering to Kubernetes storage class syncer" \


### PR DESCRIPTION
- Update Alpine base image (cf release notes for [3.13](https://alpinelinux.org/posts/Alpine-3.13.0-released.html) and [3.14](https://alpinelinux.org/posts/Alpine-3.14.0-released.html))
- Clarify Dockerfile
- Update GitHub Actions runner (Ubuntu 18.04 to Ubuntu 20.04) and update golangci-lint