### PR TITLE
Change CloudStack config filename, to match the CS k8s provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /bin
 /test/e2e/e2e.test
 /test/e2e/ginkgo
-/cloudstack.ini
+cloud-config

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ plugin for [Apache CloudStack](https://cloudstack.apache.org/).
 
 ### Configuration
 
-Create the CloudStack configuration file `cloudstack.ini`.
+Create the CloudStack configuration file `cloud-config`.
 
 It should have the following format, defined for the [CloudStack Kubernetes Provider](https://github.com/apache/cloudstack-kubernetes-provider):
 
@@ -47,7 +47,7 @@ Create a secret named `cloudstack-secret` in namespace `kube-system`:
 ```
 kubectl create secret generic \
   --namespace kube-system \
-  --from-file ./cloudstack.ini \
+  --from-file ./cloud-config \
   cloudstack-secret
 ```
 

--- a/cmd/cloudstack-csi-driver/main.go
+++ b/cmd/cloudstack-csi-driver/main.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	endpoint         = flag.String("endpoint", "unix:///tmp/csi.sock", "CSI endpoint")
-	cloudstackconfig = flag.String("cloudstackconfig", "./cloudstack.ini", "CloudStack configuration file")
+	cloudstackconfig = flag.String("cloudstackconfig", "./cloud-config", "CloudStack configuration file")
 	nodeName         = flag.String("nodeName", "", "Node name")
 	debug            = flag.Bool("debug", false, "Enable debug logging")
 	showVersion      = flag.Bool("version", false, "Show version")

--- a/cmd/cloudstack-csi-sc-syncer/README.md
+++ b/cmd/cloudstack-csi-sc-syncer/README.md
@@ -87,7 +87,7 @@ spec:
         - name: cloudstack-csi-sc-syncer
           image: quay.io/apalia/cloudstack-csi-sc-syncer:${version}
           args:
-            - "-cloudstackconfig=/etc/cloudstack-csi-driver/cloudstack.ini"
+            - "-cloudstackconfig=/etc/cloudstack-csi-driver/cloud-config"
             - "-kubeconfig=-"
           volumeMounts:
             - name: cloudstack-conf

--- a/cmd/cloudstack-csi-sc-syncer/main.go
+++ b/cmd/cloudstack-csi-sc-syncer/main.go
@@ -16,7 +16,7 @@ import (
 const agent = "cloudstack-csi-sc-syncer"
 
 var (
-	cloudstackconfig = flag.String("cloudstackconfig", "./cloudstack.ini", "CloudStack configuration file")
+	cloudstackconfig = flag.String("cloudstackconfig", "./cloud-config", "CloudStack configuration file")
 	kubeconfig       = flag.String("kubeconfig", path.Join(os.Getenv("HOME"), ".kube/config"), "Kubernetes configuration file. Use \"-\" to use in-cluster configuration.")
 	label            = flag.String("label", "app.kubernetes.io/managed-by="+agent, "")
 	namePrefix       = flag.String("namePrefix", "cloudstack-", "")

--- a/deploy/k8s/controller-deployment.yaml
+++ b/deploy/k8s/controller-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: Always
           args:
             - "-endpoint=$(CSI_ENDPOINT)"
-            - "-cloudstackconfig=/etc/cloudstack-csi-driver/cloudstack.ini"
+            - "-cloudstackconfig=/etc/cloudstack-csi-driver/cloud-config"
             - "-debug"
           env:
             - name: CSI_ENDPOINT

--- a/deploy/k8s/node-daemonset.yaml
+++ b/deploy/k8s/node-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
           imagePullPolicy: Always
           args:
             - "-endpoint=$(CSI_ENDPOINT)"
-            - "-cloudstackconfig=/etc/cloudstack-csi-driver/cloudstack.ini"
+            - "-cloudstackconfig=/etc/cloudstack-csi-driver/cloud-config"
             - "-nodeName=$(NODE_NAME)"
             - "-debug"
           env:


### PR DESCRIPTION
The CloudStack Kubernetes provider started using `cloud-config` instead of `cloudstack.ini` in https://github.com/apache/cloudstack-kubernetes-provider/commit/8a3efaf9a1f0e75494184a8e5a94ebeb6113a304

Using the same name in the CSI driver allows the users to use the same secret.