### PR TITLE
Added project id support to cloustack-csi-driver. 

### DIFF
--- a/deploy/k8s/controller-deployment.yaml
+++ b/deploy/k8s/controller-deployment.yaml
@@ -45,6 +45,8 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
             - name: cloudstack-conf
               mountPath: /etc/cloudstack-csi-driver
+            - name: cloud-init-dir
+              mountPath: /run/cloud-init/
 
         - name: external-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.4
@@ -79,3 +81,7 @@ spec:
         - name: cloudstack-conf
           secret:
             secretName: cloudstack-secret
+        - name: cloud-init-dir
+          hostPath:
+            path: /run/cloud-init/
+            type: Directory

--- a/deploy/k8s/controller-deployment.yaml
+++ b/deploy/k8s/controller-deployment.yaml
@@ -45,9 +45,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
             - name: cloudstack-conf
               mountPath: /etc/cloudstack-csi-driver
-            - name: cloud-init-dir
-              mountPath: /run/cloud-init/
-              
+
         - name: external-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.4
           imagePullPolicy: IfNotPresent
@@ -81,7 +79,3 @@ spec:
         - name: cloudstack-conf
           secret:
             secretName: cloudstack-secret
-        - name: cloud-init-dir
-          hostPath:
-            path: /run/cloud-init/
-            type: Directory

--- a/deploy/k8s/controller-deployment.yaml
+++ b/deploy/k8s/controller-deployment.yaml
@@ -45,7 +45,9 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
             - name: cloudstack-conf
               mountPath: /etc/cloudstack-csi-driver
-
+            - name: cloud-init-dir
+              mountPath: /run/cloud-init/
+              
         - name: external-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.4
           imagePullPolicy: IfNotPresent
@@ -79,3 +81,7 @@ spec:
         - name: cloudstack-conf
           secret:
             secretName: cloudstack-secret
+        - name: cloud-init-dir
+          hostPath:
+            path: /run/cloud-init/
+            type: Directory

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -54,10 +54,11 @@ var (
 // client is the implementation of Interface.
 type client struct {
 	*cloudstack.CloudStackClient
+	projectID string
 }
 
 // New creates a new cloud connector, given its configuration.
 func New(config *Config) Interface {
 	csClient := cloudstack.NewAsyncClient(config.APIURL, config.APIKey, config.SecretKey, config.VerifySSL)
-	return &client{csClient}
+	return &client{csClient, config.ProjectID}
 }

--- a/pkg/cloud/config.go
+++ b/pkg/cloud/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	APIKey    string
 	SecretKey string
 	VerifySSL bool
+	ProjectID string
 }
 
 // csConfig wraps the config for the CloudStack cloud provider.
@@ -42,5 +43,6 @@ func ReadConfig(configFilePath string) (*Config, error) {
 		APIKey:    cfg.Global.APIKey,
 		SecretKey: cfg.Global.SecretKey,
 		VerifySSL: cfg.Global.SSLNoVerify,
+		ProjectID: cfg.Global.ProjectID,
 	}, nil
 }

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -49,9 +49,9 @@ func (c *client) metadataInstanceID(ctx context.Context) string {
 	return ""
 }
 
-func (c *client) metadataProjectID(ctx context.Context) (string) {
+func (c *client) metadataProjectID(ctx context.Context) string {
 	slog := ctxzap.Extract(ctx).Sugar()
-	
+
 	// Try cloud-init
 	slog.Debug("Try with cloud-init")
 	if _, err := os.Stat(cloudInitInstanceFilePath); err == nil {
@@ -60,12 +60,12 @@ func (c *client) metadataProjectID(ctx context.Context) (string) {
 		if err != nil {
 			slog.Errorf("Cannot read cloud-init instance data: %v", err)
 		} else {
-			if ciData.Ds.Metadata.ProjectID != "" {			
+			if ciData.Ds.Metadata.ProjectID != "" {
 				return ciData.Ds.Metadata.ProjectID
 			}
 		}
 		slog.Error("cloud-init project ID is not provided")
-	} 
+	}
 
 	slog.Debug("CloudStack project ID not found in meta-data.")
 	return ""
@@ -83,11 +83,11 @@ type cloudInitV1 struct {
 }
 
 type cloudInitDs struct {
-  Metadata cloudInitMetadata `json:"meta_data"`
+	Metadata cloudInitMetadata `json:"meta_data"`
 }
 
 type cloudInitMetadata struct {
-	ProjectID  string `json:"project-uuid"`
+	ProjectID string `json:"project-uuid"`
 }
 
 func (c *client) readCloudInit(ctx context.Context, instanceFilePath string) (*cloudInitInstanceData, error) {

--- a/pkg/cloud/vms.go
+++ b/pkg/cloud/vms.go
@@ -12,14 +12,16 @@ func (c *client) GetVMByID(ctx context.Context, vmID string) (*VM, error) {
 	ctxzap.Extract(ctx).Sugar().Infow("CloudStack API call", "command", "ListVirtualMachines", "params", map[string]string{
 		"id": vmID,
 	})
-	
-	//get projectid from metadata
-	projectID := c.metadataProjectID(ctx)
 
-	if projectID != "" {
-		p.SetProjectid(projectID)
+	if c.projectID == "" {
+		//get projectid from metadata
+		c.projectID = c.metadataProjectID(ctx)
 	}
-	
+
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
+	}
+
 	l, err := c.VirtualMachine.ListVirtualMachines(p)
 	if err != nil {
 		return nil, err
@@ -43,14 +45,16 @@ func (c *client) getVMByName(ctx context.Context, name string) (*VM, error) {
 	ctxzap.Extract(ctx).Sugar().Infow("CloudStack API call", "command", "ListVirtualMachines", "params", map[string]string{
 		"name": name,
 	})
-	
-	//get projectid from metadata
-	projectID := c.metadataProjectID(ctx)
 
-	if projectID != "" {
-		p.SetProjectid(projectID)
+	if c.projectID == "" {
+		//get projectid from metadata
+		c.projectID = c.metadataProjectID(ctx)
 	}
-	
+
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
+	}
+
 	l, err := c.VirtualMachine.ListVirtualMachines(p)
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/vms.go
+++ b/pkg/cloud/vms.go
@@ -12,6 +12,14 @@ func (c *client) GetVMByID(ctx context.Context, vmID string) (*VM, error) {
 	ctxzap.Extract(ctx).Sugar().Infow("CloudStack API call", "command", "ListVirtualMachines", "params", map[string]string{
 		"id": vmID,
 	})
+	
+	//get projectid from metadata
+	projectID := c.metadataProjectID(ctx)
+
+	if projectID != "" {
+		p.SetProjectid(projectID)
+	}
+	
 	l, err := c.VirtualMachine.ListVirtualMachines(p)
 	if err != nil {
 		return nil, err
@@ -35,6 +43,14 @@ func (c *client) getVMByName(ctx context.Context, name string) (*VM, error) {
 	ctxzap.Extract(ctx).Sugar().Infow("CloudStack API call", "command", "ListVirtualMachines", "params", map[string]string{
 		"name": name,
 	})
+	
+	//get projectid from metadata
+	projectID := c.metadataProjectID(ctx)
+
+	if projectID != "" {
+		p.SetProjectid(projectID)
+	}
+	
 	l, err := c.VirtualMachine.ListVirtualMachines(p)
 	if err != nil {
 		return nil, err

--- a/pkg/cloud/volumes.go
+++ b/pkg/cloud/volumes.go
@@ -14,6 +14,16 @@ func (c *client) GetVolumeByID(ctx context.Context, volumeID string) (*Volume, e
 	ctxzap.Extract(ctx).Sugar().Infow("CloudStack API call", "command", "ListVolumes", "params", map[string]string{
 		"id": volumeID,
 	})
+
+	if c.projectID == "" {
+		//get projectid from metadata
+		c.projectID = c.metadataProjectID(ctx)
+	}
+
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
+	}
+
 	l, err := c.Volume.ListVolumes(p)
 	if err != nil {
 		return nil, err
@@ -43,6 +53,16 @@ func (c *client) GetVolumeByName(ctx context.Context, name string) (*Volume, err
 	ctxzap.Extract(ctx).Sugar().Infow("CloudStack API call", "command", "ListVolumes", "params", map[string]string{
 		"name": name,
 	})
+
+	if c.projectID == "" {
+		//get projectid from metadata
+		c.projectID = c.metadataProjectID(ctx)
+	}
+
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
+	}
+
 	l, err := c.Volume.ListVolumes(p)
 	if err != nil {
 		return nil, err
@@ -72,6 +92,15 @@ func (c *client) CreateVolume(ctx context.Context, diskOfferingID, zoneID, name 
 	p.SetZoneid(zoneID)
 	p.SetName(name)
 	p.SetSize(sizeInGB)
+
+	if c.projectID == "" {
+		//get projectid from metadata
+		c.projectID = c.metadataProjectID(ctx)
+	}
+
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
+	}
 	ctxzap.Extract(ctx).Sugar().Infow("CloudStack API call", "command", "CreateVolume", "params", map[string]string{
 		"diskofferingid": diskOfferingID,
 		"zoneid":         zoneID,


### PR DESCRIPTION
Project ID is added to cloudstack-csi-driver. Without project ID, "Not Found" error was returned on the request. Project ID is retrieved from cloud-init cloudstack instance metadata if project ID is not supplied from cloud-config. Recommended to mount cloud-init-dir on cloudstack-csi-controller as well as on cloudstack-csi-node containers. 