### PR TITLE
updating "master" label to "control-plane"

### DIFF
--- a/deploy/k8s/controller-deployment.yaml
+++ b/deploy/k8s/controller-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: cloudstack-csi-controller
       nodeSelector:
         kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - effect: NoExecute
           operator: Exists


### PR DESCRIPTION
Since kubernetes 1.20 control plane nodes have the role "control-plane" instead of "master". Deploying the manifest with the wrong role will not work anymore. 